### PR TITLE
API method to stop video preview

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ function onStartClicked()
 }
 ```
 
+### stop
+stop video preview, then CPU and Memory consumption will drop.<br>
+
+```javascript
+window.CanvasCamera.stop();
+```
+
 ### takePicture
 take a photo.<br>
 
@@ -256,6 +263,7 @@ CanvasCamera.PictureSourceType = {
             <br/>
             
             <input type="button" value="Take a picture" onclick="onTakePicture();" />
+            <input type="button" value="Stop preview" onclick="onStopPreview();" />
 
 
         </div>
@@ -327,6 +335,12 @@ CanvasCamera.PictureSourceType = {
             function onTakeSuccess(data) {
                 //
             }
+            
+            function onStopPreview() {
+                CanvasCamera.stop();
+            }
+            
+
         </script>
     </body>
 </html>

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         id="com.keith.cordova.plugin.canvascamera"
-        version="1.0.0dev">
+        version="1.1.0">
 
     <name>CanvasCamera</name>
 

--- a/www/CanvasCamera.js
+++ b/www/CanvasCamera.js
@@ -40,7 +40,7 @@ cordova.define("cordova/plugin/CanvasCamera", function(require, exports, module)
                 // rotate 90
                 _this._context.translate(_this._width/2, _this._height/2);
                 _this._context.rotate((90 - window.orientation) *Math.PI/180);
-                _this._context.drawImage(_this._camImage, 0, 0, 320, 320, -_this._width/2, -_this._height/2, _this._width, _this._height);
+                _this._context.drawImage(_this._camImage, 0, 0, 352, 288, -_this._width/2, -_this._height/2, _this._width, _this._height);
                 //
                 _this._context.restore();
             }
@@ -50,7 +50,7 @@ cordova.define("cordova/plugin/CanvasCamera", function(require, exports, module)
                 // rotate 90
                 _this._context.translate(_this._width/2, _this._height/2);
                 _this._context.rotate((90 - window.orientation)*Math.PI/180);
-                _this._context.drawImage(_this._camImage, 0, 0, 320, 320, -_this._height/2, -_this._width/2, _this._height, _this._width);
+                _this._context.drawImage(_this._camImage, 0, 0, 352, 288, -_this._height/2, -_this._width/2, _this._height, _this._width);
                 //
                 _this._context.restore();
             }

--- a/www/CanvasCamera.js
+++ b/www/CanvasCamera.js
@@ -40,7 +40,7 @@ cordova.define("cordova/plugin/CanvasCamera", function(require, exports, module)
                 // rotate 90
                 _this._context.translate(_this._width/2, _this._height/2);
                 _this._context.rotate((90 - window.orientation) *Math.PI/180);
-                _this._context.drawImage(_this._camImage, 0, 0, 352, 288, -_this._width/2, -_this._height/2, _this._width, _this._height);
+                _this._context.drawImage(_this._camImage, 0, 0, 320, 320, -_this._width/2, -_this._height/2, _this._width, _this._height);
                 //
                 _this._context.restore();
             }
@@ -50,7 +50,7 @@ cordova.define("cordova/plugin/CanvasCamera", function(require, exports, module)
                 // rotate 90
                 _this._context.translate(_this._width/2, _this._height/2);
                 _this._context.rotate((90 - window.orientation)*Math.PI/180);
-                _this._context.drawImage(_this._camImage, 0, 0, 352, 288, -_this._height/2, -_this._width/2, _this._height, _this._width);
+                _this._context.drawImage(_this._camImage, 0, 0, 320, 320, -_this._height/2, -_this._width/2, _this._height, _this._width);
                 //
                 _this._context.restore();
             }
@@ -64,6 +64,10 @@ cordova.define("cordova/plugin/CanvasCamera", function(require, exports, module)
 
     CanvasCamera.prototype.start = function(options) {
         cordova.exec(false, false, "CanvasCamera", "startCapture", [options]);
+    };
+
+    CanvasCamera.prototype.stop = function() {
+        cordova.exec(false, false, "CanvasCamera", "stopCapture", []);
     };
 
 


### PR DESCRIPTION
Stoping the preview should create a huge drop in CPU and memory consumption on the app.
